### PR TITLE
build(deps): bump Microsoft.Build.* from 15.9.20 to 15.9.30 

### DIFF
--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
@@ -25,9 +25,9 @@
 	<ItemGroup>
 		<PackageReference Include="Mono.Cecil" Version="0.11.5" PrivateAssets="all" GeneratePathProperty="true" />
 		<PackageReference Include="System.CodeDom" Version="7.0.0" PrivateAssets="all" GeneratePathProperty="true" />
-		<PackageReference Include="Microsoft.Build" Version="15.9.20" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Build" Version="15.9.30" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Build.Framework" Version="15.9.30" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.30" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.30" PrivateAssets="all" />
 	</ItemGroup>
 

--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
@@ -25,10 +25,10 @@
 	<ItemGroup>
 		<PackageReference Include="Mono.Cecil" Version="0.11.5" PrivateAssets="all" GeneratePathProperty="true" />
 		<PackageReference Include="System.CodeDom" Version="7.0.0" PrivateAssets="all" GeneratePathProperty="true" />
-		<PackageReference Include="Microsoft.Build" Version="17.14.8" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Build.Framework" Version="17.14.8" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.14.8" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.8" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Build" Version="15.9.30" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Build.Framework" Version="15.9.30" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.30" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.30" PrivateAssets="all" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
@@ -25,7 +25,7 @@
 	<ItemGroup>
 		<PackageReference Include="Mono.Cecil" Version="0.11.5" PrivateAssets="all" GeneratePathProperty="true" />
 		<PackageReference Include="System.CodeDom" Version="7.0.0" PrivateAssets="all" GeneratePathProperty="true" />
-		<PackageReference Include="Microsoft.Build" Version="15.9.30" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Build" Version="15.9.20" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Build.Framework" Version="15.9.30" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.30" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.30" PrivateAssets="all" />

--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
@@ -28,7 +28,7 @@
 		<PackageReference Include="Microsoft.Build" Version="15.9.20" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.30" PrivateAssets="all" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
@@ -25,10 +25,10 @@
 	<ItemGroup>
 		<PackageReference Include="Mono.Cecil" Version="0.11.5" PrivateAssets="all" GeneratePathProperty="true" />
 		<PackageReference Include="System.CodeDom" Version="7.0.0" PrivateAssets="all" GeneratePathProperty="true" />
-		<PackageReference Include="Microsoft.Build" Version="15.9.20" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Build.Framework" Version="15.9.30" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.30" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.30" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Build" Version="17.14.8" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Build.Framework" Version="17.14.8" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.14.8" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.8" PrivateAssets="all" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Essentials/src/Accelerometer/AccelerometerQueue.shared.cs
+++ b/src/Essentials/src/Accelerometer/AccelerometerQueue.shared.cs
@@ -25,8 +25,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			added.IsAccelerating = accelerating;
 			added.Next = null;
 
-			if (newest != null)
-				newest.Next = added;
+			newest?.Next = added;
 
 			newest = added;
 

--- a/src/Essentials/src/Accelerometer/AccelerometerQueue.shared.cs
+++ b/src/Essentials/src/Accelerometer/AccelerometerQueue.shared.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Maui.Devices.Sensors
 			added.IsAccelerating = accelerating;
 			added.Next = null;
 
-			newest?.Next = added;
+			if (newest != null)
+				newest.Next = added;
 
 			newest = added;
 

--- a/src/SingleProject/Resizetizer/src/Resizetizer.csproj
+++ b/src/SingleProject/Resizetizer/src/Resizetizer.csproj
@@ -25,10 +25,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="17.14.8" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.14.8" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.14.8" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.8" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build" Version="15.9.30" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.9.30" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.30" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.30" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="ResizetizerPackages.projitems" />

--- a/src/SingleProject/Resizetizer/src/Resizetizer.csproj
+++ b/src/SingleProject/Resizetizer/src/Resizetizer.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.Build" Version="15.9.20" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.30" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="ResizetizerPackages.projitems" />

--- a/src/SingleProject/Resizetizer/src/Resizetizer.csproj
+++ b/src/SingleProject/Resizetizer/src/Resizetizer.csproj
@@ -25,9 +25,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="15.9.20" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build" Version="15.9.30" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.9.30" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.30" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.30" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/SingleProject/Resizetizer/src/Resizetizer.csproj
+++ b/src/SingleProject/Resizetizer/src/Resizetizer.csproj
@@ -25,10 +25,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="15.9.20" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.9.30" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.30" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.30" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build" Version="17.14.8" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.14.8" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.14.8" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.8" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="ResizetizerPackages.projitems" />

--- a/src/SingleProject/Resizetizer/src/Resizetizer.csproj
+++ b/src/SingleProject/Resizetizer/src/Resizetizer.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="15.9.30" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build" Version="15.9.20" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Framework" Version="15.9.30" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.30" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.30" PrivateAssets="all" />


### PR DESCRIPTION
Microsoft.Build.Tasks.Core 15.9.20 has at one vulnerability with high severity. Advisory: https://github.com/advisories/GHSA-h4j7-5rxr-p4wc

Changed:
- Microsoft.Build
- Microsoft.Build.Framework
- Microsoft.Build.Utilities.Core
- Microsoft.Build.Tasks.Core
